### PR TITLE
New style variables for map

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable route_nexthop_types {
 
 variable "tags" {
   description = "The tags to associate with your network and subnets."
-  type        = "map"
+  type        = map(string)
 
   default = {
     tag1 = ""


### PR DESCRIPTION
Use terraform 0.12 style variables.
Same as other modules, like: https://github.com/Azure/terraform-azurerm-vnet/blob/master/variables.tf

Replace "map" with map(string) for tags, same like terraform-azurerm-vnet.

Fix issue #3 